### PR TITLE
feat: Add global config for notification config

### DIFF
--- a/src/globals/Notification.ts
+++ b/src/globals/Notification.ts
@@ -1,0 +1,81 @@
+import { GlobalConfig } from 'payload';
+
+const Notification: GlobalConfig = {
+    slug: 'notification',
+    label: 'Website Notification',
+    access: {
+        read: () => true,
+    },
+    fields: [
+        {
+            name: 'enabled',
+            type: 'checkbox',
+            label: 'Show Notification',
+            defaultValue: false,
+            required: true,
+        },
+        {
+            name: 'type',
+            type: 'select',
+            label: 'Notification Type',
+            required: true,
+            defaultValue: 'banner',
+            options: [
+                { label: 'Banner', value: 'banner' },
+                { label: 'Popup', value: 'popup' },
+            ],
+            admin: {
+                condition: (_, siblingData) => siblingData.enabled === true,
+            },
+        },
+        {
+            name: 'text',
+            type: 'text',
+            label: 'Notification Text',
+            required: true,
+            admin: {
+                condition: (_, siblingData) => siblingData.enabled === true,
+            },
+        },
+        {
+            name: 'url',
+            type: 'text',
+            label: 'Notification URL',
+            admin: {
+                condition: (_, siblingData) => siblingData.enabled === true,
+            },
+        },
+        {
+            name: 'urlText',
+            type: 'text',
+            label: 'Link Text',
+            admin: {
+                condition: (_, siblingData) => siblingData.enabled === true && !!siblingData.url,
+            },
+        },
+        {
+            name: 'leftImage',
+            type: 'upload',
+            label: 'Left Image',
+            relationTo: 'media',
+            required: false,
+            admin: {
+                condition: (_, siblingData) =>
+                    siblingData.enabled === true && siblingData.type === 'popup',
+            },
+        },
+        {
+            name: 'rightImage',
+            type: 'upload',
+            label: 'Right Image',
+            relationTo: 'media',
+            required: false,
+            admin: {
+                condition: (_, siblingData) =>
+                    siblingData.enabled === true && siblingData.type === 'popup',
+            },
+        },
+    ],
+};
+
+export default Notification;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -93,8 +93,12 @@ export interface Config {
     db: {
         defaultIDType: string;
     };
-    globals: {};
-    globalsSelect: {};
+    globals: {
+        notification: Notification;
+    };
+    globalsSelect: {
+        notification: NotificationSelect<false> | NotificationSelect<true>;
+    };
     locale: null;
     user: User & {
         collection: 'users';
@@ -125,18 +129,22 @@ export interface UserAuthOperations {
 /** This interface was referenced by `Config`'s JSON-Schema via the `definition` "users". */
 export interface User {
     id: string;
+    email: string;
+    emailVerified?: string | null;
+    name?: string | null;
+    image?: string | null;
     /** Users can have one or many roles */
     roles?: ('admin' | 'openSource' | 'events' | 'sponsorships')[] | null;
+    accounts?:
+        | {
+              id?: string | null;
+              provider: string;
+              providerAccountId: string;
+              type: string;
+          }[]
+        | null;
     updatedAt: string;
     createdAt: string;
-    email: string;
-    resetPasswordToken?: string | null;
-    resetPasswordExpiration?: string | null;
-    salt?: string | null;
-    hash?: string | null;
-    loginAttempts?: number | null;
-    lockUntil?: string | null;
-    password?: string | null;
 }
 /** This interface was referenced by `Config`'s JSON-Schema via the `definition` "media". */
 export interface Media {
@@ -315,16 +323,22 @@ export interface PayloadMigration {
 }
 /** This interface was referenced by `Config`'s JSON-Schema via the `definition` "users_select". */
 export interface UsersSelect<T extends boolean = true> {
+    id?: T;
+    email?: T;
+    emailVerified?: T;
+    name?: T;
+    image?: T;
     roles?: T;
+    accounts?:
+        | T
+        | {
+              id?: T;
+              provider?: T;
+              providerAccountId?: T;
+              type?: T;
+          };
     updatedAt?: T;
     createdAt?: T;
-    email?: T;
-    resetPasswordToken?: T;
-    resetPasswordExpiration?: T;
-    salt?: T;
-    hash?: T;
-    loginAttempts?: T;
-    lockUntil?: T;
 }
 /** This interface was referenced by `Config`'s JSON-Schema via the `definition` "media_select". */
 export interface MediaSelect<T extends boolean = true> {
@@ -427,6 +441,35 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
     batch?: T;
     updatedAt?: T;
     createdAt?: T;
+}
+/** This interface was referenced by `Config`'s JSON-Schema via the `definition` "notification". */
+export interface Notification {
+    id: string;
+    enabled: boolean;
+    type?: ('banner' | 'popup') | null;
+    text?: string | null;
+    url?: string | null;
+    urlText?: string | null;
+    leftImage?: (string | null) | Media;
+    rightImage?: (string | null) | Media;
+    updatedAt?: string | null;
+    createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema via the `definition`
+ * "notification_select".
+ */
+export interface NotificationSelect<T extends boolean = true> {
+    enabled?: T;
+    type?: T;
+    text?: T;
+    url?: T;
+    urlText?: T;
+    leftImage?: T;
+    rightImage?: T;
+    updatedAt?: T;
+    createdAt?: T;
+    globalType?: T;
 }
 /** This interface was referenced by `Config`'s JSON-Schema via the `definition` "auth". */
 export interface Auth {

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -13,6 +13,7 @@ import { Projects } from './collections/Projects';
 import { Sponsors } from './collections/Sponsors';
 import { Tech_Stack } from './collections/TechStack';
 import { Users } from './collections/Users';
+import Notification from './globals/Notification';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -32,6 +33,7 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
+  globals: [Notification],
   routes: {
     admin: '/',
   },


### PR DESCRIPTION
### Description
Add global config for notification config.

### Changes Made
- Added global config for notification config
- Have fields for enabled, notifcation type (banner or popup), notifcation text, notifcation url, url text, left image, and right image

### Related Issues
Fixes #16 

### Additional Notes
*Add any other notes or screenshots that might be helpful for the reviewers.*
